### PR TITLE
Atlas: Adding infos for Termacious Trickocity

### DIFF
--- a/web/_js/atlas.js
+++ b/web/_js/atlas.js
@@ -226,7 +226,7 @@ var atlas = [
 {"id":176,"name": "Interlingue", "description": "Flag of Interlingue, an IAL to communicate between Western European languages.", "website": "https://occidental-lang.com", "subreddit": "/r/interlingue", "center": [ 768.5, 328.5 ], "path": [ [ 765.5, 326.5 ], [ 770.5, 326.5 ], [ 770.5, 329.5 ], [ 765.5, 329.5 ] ] },
 {"id":177, "name": "Viossa", "description": "Flag of the conpidgin Viossa.", "website": "", "subreddit": "/r/viossa", "center": [ 775.5, 296.5 ], "path": [ [ 769.5, 290.5 ], [ 780.5, 290.5 ], [ 780.5, 301.5 ], [ 769.5, 301.5 ] ] },
 {"id":178, "name": "Lojban", "description": "Flag of Lojban", "website": "https://lojban.org", "subreddit": "/r/lojban", "center": [ 760.5, 328.5 ], "path": [ [ 763.5, 326.5 ], [ 757.5, 326.5 ], [ 757.5, 330.5 ], [ 763.5, 330.5 ] ] },
-
+{ "id": 180, "name": "Termacious Trickocity", "description": "We are a Halo tricking team that consists of many great trickers from all over the internet.", "website": "https://www.youtube.com/c/TermaciousTrickocity", "subreddit": "", "center": [ 1211.5, 71.5 ], "path": [ [ 1208.5, 68.5 ], [ 1214.5, 68.5 ], [ 1214.5, 74.5 ], [ 1208.5, 74.5 ], [ 1208.5, 68.5 ] ] },
 ];
 
 //console.log("There are "+atlas.length+" entries in the Atlas.");


### PR DESCRIPTION
Adding the information for my friends about their "Termacious Trickocity" logo, next to Halo Création and Hidden League Gaming.

I was not sure if I should add them with the one of my community or as a separate pull request, sorry if I chose the wrong option..!