### PR TITLE
Added atlas entry for officer module symbol, part of the Eve Online artwork.

### DIFF
--- a/web/_js/atlas.js
+++ b/web/_js/atlas.js
@@ -226,7 +226,39 @@ var atlas = [
 {"id":176,"name": "Interlingue", "description": "Flag of Interlingue, an IAL to communicate between Western European languages.", "website": "https://occidental-lang.com", "subreddit": "/r/interlingue", "center": [ 768.5, 328.5 ], "path": [ [ 765.5, 326.5 ], [ 770.5, 326.5 ], [ 770.5, 329.5 ], [ 765.5, 329.5 ] ] },
 {"id":177, "name": "Viossa", "description": "Flag of the conpidgin Viossa.", "website": "", "subreddit": "/r/viossa", "center": [ 775.5, 296.5 ], "path": [ [ 769.5, 290.5 ], [ 780.5, 290.5 ], [ 780.5, 301.5 ], [ 769.5, 301.5 ] ] },
 {"id":178, "name": "Lojban", "description": "Flag of Lojban", "website": "https://lojban.org", "subreddit": "/r/lojban", "center": [ 760.5, 328.5 ], "path": [ [ 763.5, 326.5 ], [ 757.5, 326.5 ], [ 757.5, 330.5 ], [ 763.5, 330.5 ] ] },
-
+    {
+        "id": 0,
+        "name": "Officer symbol",
+        "description": "Eve Online (see right) symbol for officer modules, some of the strongest and rarest modules in game.",
+        "website": "https://wiki.eveuniversity.org/Faction_modules#Officer",
+        "subreddit": "/r/eve",
+        "center": [
+                4.5,
+                38.5
+        ],
+        "path": [
+                [
+                        0.5,
+                        34.5
+                ],
+                [
+                        12.5,
+                        34.5
+                ],
+                [
+                        13.5,
+                        34.5
+                ],
+                [
+                        0.5,
+                        47.5
+                ],
+                [
+                        0.5,
+                        34.5
+                ]
+        ]
+    }
 ];
 
 //console.log("There are "+atlas.length+" entries in the Atlas.");


### PR DESCRIPTION
    {
        "id": 0,
        "name": "Officer symbol",
        "description": "Eve Online (see right) symbol for officer modules, some of the strongest and rarest modules in game.",
        "website": "https://wiki.eveuniversity.org/Faction_modules#Officer",
        "subreddit": "/r/eve",
        "center": [
                4.5,
                38.5
        ],
        "path": [
                [
                        0.5,
                        34.5
                ],
                [
                        12.5,
                        34.5
                ],
                [
                        13.5,
                        34.5
                ],
                [
                        0.5,
                        47.5
                ],
                [
                        0.5,
                        34.5
                ]
        ]
    }