### PR TITLE
Fix cleanup instructions & remove useless heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you don't know GitHub and wanted to submit new entries or request changes to 
 
 ### Map Contributions
 
-<h4><b>WE ONLY ACCEPT NEW CONTRIBUTIONS ON REDDIT</b></h4>
+**WE ONLY ACCEPT NEW CONTRIBUTIONS ON REDDIT!**
 
 To contribute to the map, we require a certain format for artwork region and labels. This can be generated on the [contributing page](https://place-atlas.stefanocoding.me/index.html?mode=draw) on the website. 
 
@@ -40,4 +40,4 @@ To contribute to the map, we require a certain format for artwork region and lab
 
 ### Cleaning Contributions
 
-If you spot a duplicate, please PR against `/cleanup`. To help find duplicates, run the code locally, changing line 92 of `main.js` to `overlap`.
+If you spot a duplicate, please PR against `/cleanup`. To help find duplicates, append `?mode=overlap` to the url: [`https://place-atlas.stefanocoding.me?mode=overlap`](https://place-atlas.stefanocoding.me?mode=overlap).


### PR DESCRIPTION
The cleanup instructions previously described manually editing the `main.js` file and gave a line number that is no longer correct.
Furthermore, the `overlap` mode can be activated using a simple query parameter, no need for editing code ;)

Also simplified the markup of the contribution warning.
Using a heading is not just unnecessary as it doesn't produce any stylistic changes over bold text, but also adds a confusing heading entry to the table of contents.