### PR TITLE
Add 2022 to Title Again

### DIFF
--- a/web/about.html
+++ b/web/about.html
@@ -34,7 +34,7 @@
 		
 		<meta name="viewport" content="width=device-width, height=device-height, initial-scale=1">
 		
-		<link href="./_css/style.css?version=1.0.32" rel="stylesheet" type="text/css" media="all">
+		<link href="./_css/style.css?version=1.0.33" rel="stylesheet" type="text/css" media="all">
 	</head>
 	<body>
 		<div id="wrapper">

--- a/web/index.html
+++ b/web/index.html
@@ -36,7 +36,7 @@
 		<meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no, shrink-to-fit=no">
 		<meta name="mobile-web-app-capable" content="yes">
 		
-		<link href="./_css/style.css?version=1.0.32" rel="stylesheet" type="text/css" media="all">
+		<link href="./_css/style.css?version=1.0.33" rel="stylesheet" type="text/css" media="all">
 		
 		<script type="application/ld+json">
 			{
@@ -79,7 +79,7 @@
 					     by reddit and the like as the thumbnail for the site.
 					     The original is only 5.9kB, which wouldn't get much
 					     smaller by reducing the actualy size.  -->
-					<h1 id="title">The /r/place Atlas</h1>
+					<h1 id="title">The 2022 /r/place Atlas</h1>
 				</a>
 
 			</header>


### PR DESCRIPTION
Since it turned out that https://github.com/Codixer/place-atlas/issues/523 was just caused by caching issues, I think the 2022 can be added to the title again. I also changed the version number in the link element, so caching shouldn't be a problem anymore.

Reverts https://github.com/Codixer/place-atlas/pull/518